### PR TITLE
[GH-26] Data & Cache dirs can now be sym links.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,16 @@ import (
 )
 
 func GetAppDir(appName, appDirVar, xdgDirVar, homeFallback string) string {
+    originalPath := getAppDirNoSymlink(appName, appDirVar, xdgDirVar, homeFallback)
+
+    if newPath, err := filepath.EvalSymlinks(originalPath); err != nil {
+        return originalPath
+    } else {
+        return newPath
+    }
+}
+
+func getAppDirNoSymlink(appName, appDirVar, xdgDirVar, homeFallback string) string {
 	if val, present := os.LookupEnv(appDirVar); present {
 		return val
 	} else if val, present := os.LookupEnv(xdgDirVar); present {


### PR DESCRIPTION
Sym links within the dirs are still unsupported, but at least the directories themselves can by sym links.